### PR TITLE
Fixes migration creation crash

### DIFF
--- a/app/Overrides/MigrationCreator.php
+++ b/app/Overrides/MigrationCreator.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Overrides;
+
+class MigrationCreator extends \Illuminate\Database\Migrations\MigrationCreator
+{
+    protected function ensureMigrationDoesntAlreadyExist($name, $migrationPath = null)
+    {
+        // Disable the default behavior to prevent requiring user code into app
+        // No duplicate migration check for now
+    }
+}

--- a/app/Providers/MigrationServiceProvider.php
+++ b/app/Providers/MigrationServiceProvider.php
@@ -26,7 +26,7 @@ class MigrationServiceProvider extends ServiceProvider
     {
         // Load only the migration creator, not the entire migration service provider
         $this->app->singleton(MigrationCreator::class, function ($app) {
-            return new MigrationCreator($app['files'], $app->basePath('stubs'));
+            return new \App\Overrides\MigrationCreator($app['files'], $app->basePath('stubs'));
         });
     }
 }


### PR DESCRIPTION
For "not so standard" migrations that may include user code, requiring them into the Laravel Zero instance may cause "Class not found" issues.

Disabled loading the classes, effectively disabling duplication check. May not be an issue since all classes are anonymous now.